### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 # Installation
 
-1.  Install MacTeX 2013 from [MacTeX](http://tug.org/mactex/)
+1.  Install MacTeX 2013 from [MacTeX](https://tug.org/mactex/)
 
 2.  Install the Python package `pygments` by typing `$ pip install pygments` in your shell
 
@@ -34,7 +34,7 @@ The file `example.tex` contains an examplary deck. See [example.pdf](https://git
 
 # Where to get help
 
--   Type `$ texdoc beamer` at your command line to open the comprehensive Beamer User Guide. [TeX - LaTeX Stack Exchange](http://tex.stackexchange.com/) also has a lot of material.
+-   Type `$ texdoc beamer` at your command line to open the comprehensive Beamer User Guide. [TeX - LaTeX Stack Exchange](https://tex.stackexchange.com/) also has a lot of material.
 
 # Reporting bugs and feature requests
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://tex.stackexchange.com/ with 1 occurrences migrated to:  
  https://tex.stackexchange.com/ ([https](https://tex.stackexchange.com/) result 200).
* http://tug.org/mactex/ with 1 occurrences migrated to:  
  https://tug.org/mactex/ ([https](https://tug.org/mactex/) result 200).